### PR TITLE
Fix network "deadlock"

### DIFF
--- a/rekeysrv-locl.h
+++ b/rekeysrv-locl.h
@@ -116,7 +116,8 @@ extern char *target_acl_path;
 extern int force_compat_enctype;
 extern krb5_enctype *cfg_enctypes;
 
-void child_cleanup(void) ;
+void child_cleanup_sockets(void);
+void child_cleanup_ssl(void);
 void ssl_startup(void);
 void ssl_cleanup(void);
 void net_startup(void);

--- a/srvmain.c
+++ b/srvmain.c
@@ -84,6 +84,7 @@ void run_fg(int s, struct sockaddr *sa) {
   } else {
     syslog(LOG_INFO, "Connection from unknown address type %d", sa->sa_family);
   }
+  child_cleanup_sockets();
   run_session(s);
   exit(0);
 }

--- a/srvnet.c
+++ b/srvnet.c
@@ -166,7 +166,8 @@ void net_startup(void) {
       setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on));
     }
 #endif
-     setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+    setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on));
     
     if (bind(s, p->ai_addr, p->ai_addrlen)) {
       close(s);

--- a/srvnet.c
+++ b/srvnet.c
@@ -217,13 +217,17 @@ SSL *do_ssl_accept(int s) {
   return ret;
 }
 
-void child_cleanup(void) 
+void child_cleanup_sockets(void) 
 {
   int i;
   for (i=0;i<nlfds;i++) {
     close(listenfds[i]);
     listenfds[i]=-1;
   }
+}
+
+void child_cleanup_ssl(void) 
+{
   if (sslctx)
     SSL_CTX_free(sslctx);
   sslctx=NULL;

--- a/srvops.c
+++ b/srvops.c
@@ -2078,7 +2078,7 @@ void run_session(int s) {
     fatal("Cannot allocate memory: %s", strerror(errno));
   }
   sess.ssl = do_ssl_accept(s);
-  child_cleanup();
+  child_cleanup_ssl();
 
   if (krb5_init_context(&sess.kctx))
     fatal("krb5_init_context failed");


### PR DESCRIPTION
If a client hangs/loses network/etc before the SSL connection is established, the blocked child still holds the listen sockets open, which breaks restarts.

Enable TCP keepalives and close the listen sockets even earlier than before.